### PR TITLE
Add tags to datadog events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 drone-datadog
+testenv

--- a/.tags
+++ b/.tags
@@ -1,0 +1,2 @@
+test.tags-file-tag1
+tag2 tag3

--- a/README.md
+++ b/README.md
@@ -9,20 +9,22 @@ where [environment] is generally something like "prod" or "staging" and [version
 
 When running the program or the docker instance, the following environment variables need to be set:
 
-* dd_api_key = a write-allowed API key created in https://app.datadoghq.com/account/settings#api
-* dd_release_environment = the name of the environment being deployed to
-* dd_release_version = the version fo the code being deployed
+* `dd_api_key` - a write-allowed API key created in https://app.datadoghq.com/account/settings#api
+* `dd_release_environment` - the name of the environment being deployed to
+* `dd_release_version` - the version of the code being deployed
 
-For example:
+Optional parameter:
+* `dd_event_tags` - a list of tags to add to the event
 
+Example usage:
 ```yaml
 pipeline:
-  datadog-staging:
+  datadog-event:
     image: urbint/drone-datadog
     dd_api_key: 1234567890abcdefg1234567890abcde
     dd_release_version: ${DRONE_COMMIT}
-    dd_release_environment: staging
-    when:
-      branch: master
-
+    dd_release_environment: ${DRONE_DEPLOY_TO=dev}
+    dd_event_tags: [drone, deployment, release-${DRONE_DEPLOY_TO=dev}]
 ```
+
+In addition, a `.tags` file placed at the root of the workspace will be parsed and all 'words' found will be appended to any tags provided in the pipeline definition.

--- a/datadog/types.go
+++ b/datadog/types.go
@@ -3,8 +3,9 @@ package datadog
 import "fmt"
 
 type Event struct {
-	Title       string        `json:"title"`
-	Description string        `json:"description"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags"`
 }
 
 type Error struct {

--- a/main.go
+++ b/main.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/urbint/drone-datadog/datadog"
+	"github.com/urbint/drone-datadog/tags"
 )
 
 type Args struct {
-	ApiKey    string `envconfig:"dd_api_key"`
-	Environ   string `envconfig:"dd_release_environment"`
-	Version   string `envconfig:"dd_release_version"`
+	ApiKey    string 		`envconfig:"dd_api_key"`
+	Environ   string 		`envconfig:"dd_release_environment"`
+	Version   string 		`envconfig:"dd_release_version"`
+	Tags			[]string 	`envconfig:"dd_event_tags"`
 }
 
 type DroneVars struct {
@@ -49,6 +51,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if _, err := os.Stat(".tags"); err == nil {
+		fmt.Println(".tags file found, parsing")
+		vargs.Tags = append(vargs.Tags, tags.ParseFile(".tags")...)
+	}
+
 	// create the Datadog client
 	client := datadog.NewClient(vargs.ApiKey)
 
@@ -56,6 +63,7 @@ func main() {
 	msg := datadog.Event{
 		Title: "release-" + vargs.Environ + ": " + vargs.Version,
 		Description:  "Pushed " + vargs.Version + " to " + vargs.Environ,
+		Tags: vargs.Tags,
 	}
 
 	// sends the message

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -1,0 +1,30 @@
+package tags
+
+import (
+	"bufio"
+	"log"
+	"os"
+)
+
+func ParseFile(filename string) []string {
+	var tags []string
+
+	file, err := os.Open(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Split(bufio.ScanWords)
+	for scanner.Scan() {
+		tags = append(tags, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+
+	return tags
+
+}


### PR DESCRIPTION
I needed more control over filtering events in datadog so I added support to the tags field in the the Event type.  This will parse tags that are supplied explicitly in the pipeline definition as well as append tags found in a `.tags` file at the root of the workspace (similar functionality in the [drone-docker](https://github.com/drone-plugins/drone-docker) plugin).  Sorry about the mess of commits :-)